### PR TITLE
added comments and specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
+## 2.0.2
+ - added comments and basic specs
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/lib/logstash/inputs/graphite.rb
+++ b/lib/logstash/inputs/graphite.rb
@@ -21,6 +21,8 @@ class LogStash::Inputs::Graphite < LogStash::Inputs::Tcp
   public
   def run(output_queue)
     @queue = output_queue
+    # pass self as output_queue to super Tcp#run - this is a hack so that the << calls in
+    # Tcp will actually call the << method defined below. This is twisted :P
     super(self)
   end
 

--- a/logstash-input-graphite.gemspec
+++ b/logstash-input-graphite.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-graphite'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Receive graphite metrics"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/graphite_spec.rb
+++ b/spec/inputs/graphite_spec.rb
@@ -1,1 +1,54 @@
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/inputs/graphite"
+require "logstash/timestamp"
+require "time"
+
+describe LogStash::Inputs::Graphite do
+  before do
+    srand(RSpec.configuration.seed)
+  end
+
+  let(:host) { "127.0.0.1" }
+  let(:port) { rand(5000) + 1025 }
+  let(:queue) { [] }
+
+  let(:client) { TCPSocket.new(host, port) }
+
+  subject { LogStash::Inputs::Graphite.new("host" => host, "port" => port) }
+  before :each do
+    subject.register
+    Thread.new { subject.run(queue) }
+  end
+
+  after :each do
+    subject.teardown
+  end
+
+  it "should parse a graphite message" do
+    client.write "a.b.c 10 N\n"
+    sleep 0.01 until queue.size == 1
+    expect(queue.first.to_hash).to include({"a.b.c" => 10})
+  end
+
+  it "should parse a graphite message with floats" do
+    client.write "a.b.c 10.2 N\n"
+    sleep 0.01 until queue.size == 1
+    expect(queue.first.to_hash).to include({"a.b.c" => 10.2})
+  end
+
+  it "should support using N as current timestamp" do
+    time = LogStash::Timestamp.new(Time.now)
+    expect(Time).to receive(:now) { time }
+    client.write "a.b.c 10 N\n"
+    sleep 0.01 until queue.size == 1
+    expect(queue.first["@timestamp"]).to eq(time)
+  end
+
+  it "should support using N as current timestamp" do
+    time = Time.at(Time.now.to_i) # truncate at the second
+    client.write "a.b.c 10 #{time.to_i}\n"
+    sleep 0.01 until queue.size == 1
+    expect(queue.first["@timestamp"]).to eq(LogStash::Timestamp.new(time))
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
+
+# this has been taken from the udp input, it should be DRYed
+
+class TcpHelpers
+
+  def pipelineless_input(plugin, size, &block)
+    queue = Queue.new
+    input_thread = Thread.new do
+      plugin.run(queue)
+    end
+    block.call
+    sleep 0.1 while queue.size != size
+    result = size.times.inject([]) do |acc|
+      acc << queue.pop
+    end
+    plugin.do_stop
+    input_thread.join
+    result
+  end
+end


### PR DESCRIPTION
this PR basically only add specs to validate new shutdown semantics. 

this replaces #3 - @jsvd's commit has been moved here.

As discussed in #3 I will add a new issue for eventual specs refactors. I refactored the spec to mimic what we have in the tcp input specs. we will also need to DRY the spec_helper code with the tcp and udp inputs.