### PR TITLE
remove implementation specific timestamp check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.5
+ - remove implementation specific test in specs
+
 ## 2.0.3
  - fixed specs for time handling
 

--- a/logstash-input-graphite.gemspec
+++ b/logstash-input-graphite.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-graphite'
-  s.version         = '2.0.4'
+  s.version         = '2.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Receive graphite metrics"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/graphite_spec.rb
+++ b/spec/inputs/graphite_spec.rb
@@ -51,13 +51,12 @@ describe LogStash::Inputs::Graphite do
     end
 
     it "should support using N as current timestamp" do
-      time = LogStash::Timestamp.now
-      expect(LogStash::Timestamp).to receive(:now) { time }
       result = helper.pipelineless_input(subject, 1) do
         client.write "a.b.c 10 N\n"
       end
       expect(result.size).to eq(1)
-      expect(result.first["@timestamp"]).to eq(time)
+      # 2 seconds squew should provide ample margin for any tests run slowdown
+      expect(result.first["@timestamp"].to_i).to be_within(2).of(LogStash::Timestamp.now.to_i)
     end
 
     it "should support using N as current timestamp" do


### PR DESCRIPTION
specs was using an implementation specific check which did not work using the logstash-core-event-java.

relates to elastic/logstash#4191